### PR TITLE
Added removeChildSafe() method.

### DIFF
--- a/src/ofxObject.cpp
+++ b/src/ofxObject.cpp
@@ -121,6 +121,11 @@ int ofxObject::addChild(ofxObject *child)
 	return (1);
 }
 
+void ofxObject::removeChildSafe(ofxObject *child)
+{
+    children_to_remove.push_back(child);
+}
+
 void ofxObject::removeChild(ofxObject *child)
 {
    	for (unsigned int i = 0; i < children.size(); i++) {
@@ -275,6 +280,12 @@ void ofxObject::idleBase(float iTime)
 	//call idle on all children
 	for (unsigned int i = 0; i < children.size(); i++) 
 		children[i]->idleBase(iTime);
+
+    // remove all marked children
+    for( ofxObject *child : children_to_remove ){
+        removeChild( child );
+    }
+    children_to_remove.clear();
 
     timePrev = iTime;   //eg
 }

--- a/src/ofxObject.h
+++ b/src/ofxObject.h
@@ -64,7 +64,9 @@ class ofxObject{
 	~ofxObject();
 
 	int								addChild(ofxObject *child);
-	void 							removeChild(ofxObject *child);	
+	void 							removeChild(ofxObject *child);
+    //! variant of removeChild that is safe to call within idle()
+    void                            removeChildSafe(ofxObject *child);
 	int 							isDescendant(ofxObject *iObject);
 	
 	virtual void					predraw();
@@ -142,6 +144,7 @@ class ofxObject{
 protected:	
 	vector <ofxObject *>			children;
 	vector <ofxObject *>			parents;
+    vector <ofxObject *>            children_to_remove;
 	
 	bool							shown;	
 	bool							renderDirty;


### PR DESCRIPTION
Allows children to remove themselves from parents within their
idle() method.

Needed by CallbackObject so it doesn't get called repeatedly.
