### PR TITLE
Compatibility with oF master branch 12/3/2014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,11 +92,29 @@ CORE
 	/ Removed default from setColor with 4 args
 	+ Integrated Maja's code for OF_SETCOLOR4
 	
+### ofxSosoTrueTypeFont
+	12/3/2014, AO:
+	/ In loadFont(—), changed cps data field to reflect changes in
+		ofTrueTypeFont
+	/ Replaced references to cps[i].setWidth with cps[i].advance
+	/ Changed getStringBoundingBox(—) significantly to match update ofTrueTypeFont
+		getStringBoundingBox, with the exception that we use custom-mapped
+		characters and custom kerning alignment calculation 
 	
+
+
+### ofxVideoPlayerObject
+	12/2014, AO:
+	/ Replaced ofxAVFVideoPlayer references with ofAVFoundationPlayer references
+	/ Updated video player function calls to reflect ofAVFoundationPlayer format 
+		(loadMovie changed to load, etc.)
+		
 
 EXAMPLES
 ----
 ### Structure
+	12/3/2014, AO:
+	- Removed ofxAVFVideoPlayer 
 	11/12/2014, AO:
 	/ Made all examples work with new ofxImageObject implementation.
  	5/29/2014, AO:

--- a/README.md
+++ b/README.md
@@ -32,11 +32,25 @@ For versions of openFrameworks 0.8.4 and earlier:
 
 To use release versions of oF and ofxSoso (recommended)
 ------------
+Fetch tags for both openFrameworks and ofxSoso git repos.
+```git fetch — tags```
+
+Checkout matching 
+```git fetch — tags```
+
+
+List tags for openFrameworks and checkout appropriate version.
+```git tag -l```
+```git checkout 0.8.4```
+
+List tags for ofxSoso  and checkout appropriate version.
+```git tag -l```
+```git checkout 0.8.4.0```
 
 
 To use master versions of oF and ofxSoso
 ------------
-
+No additional work is needed.
 
 
 Creating a New Example Project

--- a/README.md
+++ b/README.md
@@ -1,15 +1,43 @@
 ofxSoso
 =======
 Soso OpenFrameworks Addon
-Copyright (C) 2013 Sosolimited
+Copyright (C) 2012-2014 Sosolimited
 
 
-openFrameworks addon with scene graph, animations, enhanced text, and more. See the XCode or Visual Studio 2010 example apps for usage. Also see the top of each header file for a description of the classes and other useful notes. The addon now compiles with OFv008.
+OpenFrameworks addon that provides a scene graph structure, animations, enhanced text, and more.  Look at src header files for descriptions of each object.
 
-Dependencies
+As of 12/2014, we will tag ofxSoso releases with names corresponding to openFrameworks releases.  We recommend grabbing the oF and ofxSoso release versions for best results. 
+
+While we strive to maintain compatibility between the ofxSoso master branch and the oF master branch, only release versions are guaranteed.
+
+
+Basic instructions
 ------------
-Grab ofxAVFVideoPlayer and follow kronick's instructions for adding it to your project  
-https://github.com/sosolimited/ofxAVFVideoPlayer
+
+1 - Clone OpenFrameworks
+```git clone https://github.com/openframeworks/openframeworks.git```  
+
+2 - Clone ofxSoso in openFrameworks/addons
+```git clone https://github.com/sosolimited/ofxSoso.git```
+
+
+For versions of openFrameworks 0.8.4 and earlier:
+------------
+
+3 - Clone the Sosolimited fork of ofxAVFVideoPlayer into openFrameworks/addons
+```git clone https://github.com/sosolimited/ofxAVFVideoPlayer.git```
+
+4 - Follow kronick’s instructions for adding ofxAVFVideoPlayer to your project
+
+
+To use release versions of oF and ofxSoso (recommended)
+------------
+
+
+To use master versions of oF and ofxSoso
+------------
+
+
 
 Creating a New Example Project
 ------------
@@ -20,13 +48,18 @@ Type in your new project's name and  when prompted, agree to rename all other re
 
 Note:  You will manually have to create new schemes to match your new project name.
 
-Notes
------
-If you're using the Visual Studio example, compile and run in Release. Debug is not currently working. 
 
 Examples
 ------------
 Most ofxSoso examples run without additional addons.
 
-To run the addonGuiExample, downlaod ofxUI and place in openFrameworks/addons.
+To run the addonGuiExample, download ofxUI and place in openFrameworks/addons.
+
+
+Notes
+-----
+Examples are currently built and tested with Xcode. Visual Studio support is untested.
+
+
+
 

--- a/examples/addonGuiExample/addonExample.xcodeproj/project.pbxproj
+++ b/examples/addonGuiExample/addonExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -182,10 +180,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -366,7 +360,6 @@
 			children = (
 				E0E662CF1A13B7C0003D6B77 /* ofxUI */,
 				E0FAA179193F934F0074E3DB /* ofxXmlSettings */,
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -454,26 +447,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E0E662CF1A13B7C0003D6B77 /* ofxUI */ = {
@@ -785,12 +758,10 @@
 				E0E665771A13B7C4003D6B77 /* ofxUILabelToggle.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				E0E6657B1A13B7C4003D6B77 /* ofxUIMultiImageToggle.cpp in Sources */,
 				E0E665781A13B7C4003D6B77 /* ofxUIMinimalSlider.cpp in Sources */,
 				E0E665801A13B7C4003D6B77 /* ofxUIRotarySlider.cpp in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				E0E6656D1A13B7C4003D6B77 /* ofxUIEventArgs.cpp in Sources */,

--- a/examples/basicExample/basicExample.xcodeproj/project.pbxproj
+++ b/examples/basicExample/basicExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/basicExample/basicExample.xcodeproj/project.xcworkspace/xcshareddata/basicExample.xccheckout
+++ b/examples/basicExample/basicExample.xcodeproj/project.xcworkspace/xcshareddata/basicExample.xccheckout
@@ -10,37 +10,45 @@
 	<string>basicExample</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>636DEA6D-954D-4957-9065-99C2FBCDF121</key>
+		<key>2DE9C8846D9375EAACFABA8963120E8E7719BAF5</key>
 		<string>https://github.com/openFrameworks/openFrameworks.git</string>
-		<key>9F0B2098-43F7-4A92-8154-B4DBE4BB4D8D</key>
+		<key>C4EC4F18F21C3D57A566E22CE3B006CDAAD63503</key>
+		<string>https://github.com/sosolimited/ofxSoso.git</string>
+		<key>EBC5E2A29F125165AEBCAA19E4D8FC06D99494BA</key>
 		<string>https://github.com/aolivier/ofxAVFVideoPlayer.git</string>
-		<key>BFEBA416-1E55-4313-BA77-08160C7DD8D5</key>
-		<string>https://github.com/aolivier/ofxSoso.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>addons/ofxSoso/examples/basicExample/basicExample.xcodeproj/project.xcworkspace</string>
+	<string>examples/basicExample/basicExample.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>636DEA6D-954D-4957-9065-99C2FBCDF121</key>
+		<key>2DE9C8846D9375EAACFABA8963120E8E7719BAF5</key>
 		<string>../../../../../..</string>
-		<key>9F0B2098-43F7-4A92-8154-B4DBE4BB4D8D</key>
-		<string>../../../../../ofxAVFVideoPlayer</string>
-		<key>BFEBA416-1E55-4313-BA77-08160C7DD8D5</key>
+		<key>C4EC4F18F21C3D57A566E22CE3B006CDAAD63503</key>
 		<string>../../../..</string>
+		<key>EBC5E2A29F125165AEBCAA19E4D8FC06D99494BA</key>
+		<string>../../../../../ofxAVFVideoPlayer</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/aolivier/ofxSoso.git</string>
+	<string>https://github.com/sosolimited/ofxSoso.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>636DEA6D-954D-4957-9065-99C2FBCDF121</string>
+	<string>C4EC4F18F21C3D57A566E22CE3B006CDAAD63503</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>9F0B2098-43F7-4A92-8154-B4DBE4BB4D8D</string>
+			<string>2DE9C8846D9375EAACFABA8963120E8E7719BAF5</string>
+			<key>IDESourceControlWCCName</key>
+			<string>..</string>
+		</dict>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>EBC5E2A29F125165AEBCAA19E4D8FC06D99494BA</string>
 			<key>IDESourceControlWCCName</key>
 			<string>ofxAVFVideoPlayer</string>
 		</dict>
@@ -48,17 +56,9 @@
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>BFEBA416-1E55-4313-BA77-08160C7DD8D5</string>
+			<string>C4EC4F18F21C3D57A566E22CE3B006CDAAD63503</string>
 			<key>IDESourceControlWCCName</key>
 			<string>ofxSoso</string>
-		</dict>
-		<dict>
-			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
-			<string>public.vcs.git</string>
-			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>636DEA6D-954D-4957-9065-99C2FBCDF121</string>
-			<key>IDESourceControlWCCName</key>
-			<string>openFrameworks</string>
 		</dict>
 	</array>
 </dict>

--- a/examples/basicExample/basicExample.xcodeproj/project.xcworkspace/xcshareddata/basicExample.xccheckout
+++ b/examples/basicExample/basicExample.xcodeproj/project.xcworkspace/xcshareddata/basicExample.xccheckout
@@ -22,7 +22,7 @@
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>2DE9C8846D9375EAACFABA8963120E8E7719BAF5</key>
-		<string>../../../../../..</string>
+		<string>../../../../..</string>
 		<key>C4EC4F18F21C3D57A566E22CE3B006CDAAD63503</key>
 		<string>../../../..</string>
 		<key>EBC5E2A29F125165AEBCAA19E4D8FC06D99494BA</key>
@@ -42,7 +42,7 @@
 			<key>IDESourceControlWCCIdentifierKey</key>
 			<string>2DE9C8846D9375EAACFABA8963120E8E7719BAF5</string>
 			<key>IDESourceControlWCCName</key>
-			<string>..</string>
+			<string></string>
 		</dict>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>

--- a/examples/basicExample/basicExample.xcodeproj/xcuserdata/Sosolimited.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/examples/basicExample/basicExample.xcodeproj/xcuserdata/Sosolimited.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/examples/destructorsDev/destructorsClean.xcodeproj/project.pbxproj
+++ b/examples/destructorsDev/destructorsClean.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/emptyExample/emptyExample.xcodeproj/project.pbxproj
+++ b/examples/emptyExample/emptyExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/flipDev/flipDev.xcodeproj/project.pbxproj
+++ b/examples/flipDev/flipDev.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/gridExample/gridExample.xcodeproj/project.pbxproj
+++ b/examples/gridExample/gridExample.xcodeproj/project.pbxproj
@@ -32,8 +32,6 @@
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
 		E03E326919378D9E0034452A /* myGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E03E326719378D9E0034452A /* myGrid.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -136,10 +134,6 @@
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
 		E03E326719378D9E0034452A /* myGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = myGrid.cpp; sourceTree = "<group>"; };
 		E03E326819378D9E0034452A /* myGrid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = myGrid.h; sourceTree = "<group>"; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -215,7 +209,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -303,26 +296,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -477,9 +450,7 @@
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
 				E03E326919378D9E0034452A /* myGrid.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/scrollerExample/scrollerExample.xcodeproj/project.pbxproj
+++ b/examples/scrollerExample/scrollerExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/shaderExample/shaderExample.xcodeproj/project.pbxproj
+++ b/examples/shaderExample/shaderExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -150,10 +148,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -251,7 +245,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -339,26 +332,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E0CA470819420B5A002BC03E /* ShaderObjects */ = {
@@ -595,11 +568,9 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
 				E0CA473C19463327002BC03E /* image_mask.vert in Sources */,
 				E0CA471119423365002BC03E /* shaderColorRect.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				E0CA473E19463327002BC03E /* mouse_to_color.vert in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				E0CA473719463327002BC03E /* shaderBlurX.frag in Sources */,

--- a/examples/textExample/textExample.xcodeproj/project.pbxproj
+++ b/examples/textExample/textExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/examples/xmlExample/xmlExample.xcodeproj/project.pbxproj
+++ b/examples/xmlExample/xmlExample.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71476C1B02BAEFF003D83DFB /* ofxLineSegmentObject.cpp */; };
 		DECE37CB3668FCE5D210E34A /* ofxSosoTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 80897F89549F3B92332DE157 /* ofxSosoTrueTypeFont.cpp */; };
-		E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */; };
-		E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */; };
 		E08321E719364057000BD296 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E619364057000BD296 /* QuartzCore.framework */; };
 		E08321E919364068000BD296 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321E819364068000BD296 /* CoreMedia.framework */; };
 		E08321EB19364075000BD296 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08321EA19364075000BD296 /* AVFoundation.framework */; };
@@ -133,10 +131,6 @@
 		D270925B75974A566DDAFF49 /* ofxFboObject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxFboObject.cpp; path = ../../src/ofxFboObject.cpp; sourceTree = SOURCE_ROOT; };
 		DBA168034BF49F632FA80C41 /* ofxLetterTextObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxLetterTextObject.h; path = ../../src/ofxLetterTextObject.h; sourceTree = SOURCE_ROOT; };
 		DEEE4C7F10BBB847A31D392A /* ofxTextureObject.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextureObject.h; path = ../../src/ofxTextureObject.h; sourceTree = SOURCE_ROOT; };
-		E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoPlayer.h; sourceTree = "<group>"; };
-		E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxAVFVideoPlayer.mm; sourceTree = "<group>"; };
-		E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAVFVideoRenderer.h; sourceTree = "<group>"; };
-		E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ofxAVFVideoRenderer.m; sourceTree = "<group>"; };
 		E08321E619364057000BD296 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E08321E819364068000BD296 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		E08321EA19364075000BD296 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +206,6 @@
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */,
 				1A36ADDAF544F1D230A4DE59 /* ofxSoso */,
 			);
 			name = addons;
@@ -300,26 +293,6 @@
 				41C4BA011B579A81F3EC2040 /* ofxVideoPlayerObject.h */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		E08321AD1936401E000BD296 /* ofxAVFVideoPlayer */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D21936401E000BD296 /* src */,
-			);
-			name = ofxAVFVideoPlayer;
-			path = ../../../ofxAVFVideoPlayer;
-			sourceTree = "<group>";
-		};
-		E08321D21936401E000BD296 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E08321D31936401E000BD296 /* ofxAVFVideoPlayer.h */,
-				E08321D41936401E000BD296 /* ofxAVFVideoPlayer.mm */,
-				E08321D51936401E000BD296 /* ofxAVFVideoRenderer.h */,
-				E08321D61936401E000BD296 /* ofxAVFVideoRenderer.m */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -471,9 +444,7 @@
 				8947BB2A7B0ED26558985B9E /* ofxFboObject.cpp in Sources */,
 				A5246968290699ED6AF4B3D5 /* ofxGridSystem.cpp in Sources */,
 				45F62755794E24120E98A392 /* ofxImageObject.cpp in Sources */,
-				E08321DD1936401E000BD296 /* ofxAVFVideoPlayer.mm in Sources */,
 				026CF86B8E5DE58987E03F04 /* ofxLetterTextObject.cpp in Sources */,
-				E08321DE1936401E000BD296 /* ofxAVFVideoRenderer.m in Sources */,
 				C5011EF6997C1099FC26CC1B /* ofxLineSegmentObject.cpp in Sources */,
 				6720CB17BB1F777BD86119BD /* ofxLineStripObject.cpp in Sources */,
 				9A596E0751B532824F345053 /* ofxMessage.cpp in Sources */,

--- a/src/ofxPolygonObject.cpp
+++ b/src/ofxPolygonObject.cpp
@@ -119,7 +119,7 @@ void ofxPolygonObject::setDrawMode(int iDrawMode)
 
 void ofxPolygonObject::setTexture(ofImage *iTex)
 {
-	texture = &iTex->getTextureReference();
+	texture = &iTex->getTexture();
 }
 
 void ofxPolygonObject::setTextureByReference(ofTexture &iTex) {

--- a/src/ofxQuadStripObject.cpp
+++ b/src/ofxQuadStripObject.cpp
@@ -138,7 +138,7 @@ void ofxQuadStripObject::setDrawMode(int iDrawMode)
 
 void ofxQuadStripObject::setTexture(ofImage *iTex)
 {
-	texture = &iTex->getTextureReference();
+	texture = &iTex->getTexture();
 }
 
 void ofxQuadStripObject::enableVertexColoring(bool iEnable)

--- a/src/ofxRectangleObject.cpp
+++ b/src/ofxRectangleObject.cpp
@@ -32,14 +32,14 @@ void ofxRectangleObject::render()
 		if (fillAlpha > 0.0) {
 			ofFill();
 			ofSetColor(color.r, color.g, color.b, fillAlpha * drawMaterial->color.a/255.0);
-			ofRect(-dimensions.x/2.0f, -dimensions.y/2.0f, dimensions.x, dimensions.y);	
+      ofDrawRectangle(-dimensions.x/2.0f, -dimensions.y/2.0f, dimensions.x, dimensions.y);
 
 		}
     
 		if (strokeAlpha > 0.0) {
 			ofNoFill();
 			ofSetColor(color.r, color.g, color.b, strokeAlpha * drawMaterial->color.a/255.0);
-			ofRect(-dimensions.x/2.0f, -dimensions.y/2.0f, dimensions.x, dimensions.y);
+			ofDrawRectangle(-dimensions.x/2.0f, -dimensions.y/2.0f, dimensions.x, dimensions.y);
 		}
     
 	} else {
@@ -47,12 +47,12 @@ void ofxRectangleObject::render()
 		if (fillAlpha > 0.0) {
 			ofFill();
 			ofSetColor(color.r, color.g, color.b, fillAlpha * drawMaterial->color.a/255.0);
-			ofRect(0, 0, dimensions.x, dimensions.y);	
+			ofDrawRectangle(0, 0, dimensions.x, dimensions.y);
 		}
 		if (strokeAlpha > 0.0) {
 			ofNoFill();
 			ofSetColor(color.r, color.g, color.b, strokeAlpha * drawMaterial->color.a/255.0);
-			ofRect(0, 0, dimensions.x, dimensions.y);	
+			ofDrawRectangle(0, 0, dimensions.x, dimensions.y);
 
 		}
     

--- a/src/ofxSosoRenderer.cpp
+++ b/src/ofxSosoRenderer.cpp
@@ -3,7 +3,7 @@
 #include "ofGraphics.h"
 #include "ofAppRunner.h"
 
-ofxSosoRenderer::ofxSosoRenderer(float iWidth, float iHeight, bool iOrthographic, bool iVFlip, float iFov, float iNearDist, float iFarDist):ofGLRenderer(true)
+ofxSosoRenderer::ofxSosoRenderer(float iWidth, float iHeight, bool iOrthographic, bool iVFlip, float iFov, float iNearDist, float iFarDist):ofGLRenderer(ofGetWindowPtr())
 {
   width = iWidth;
   height = iHeight;

--- a/src/ofxSosoTrueTypeFont.cpp
+++ b/src/ofxSosoTrueTypeFont.cpp
@@ -229,7 +229,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 	if (bLoadedOk == true){
     
 		// we've already been loaded, try to clean up :
-		unloadTextures();
+//		unloadTextures();
 	}
 	//------------------------------------------------
   
@@ -384,11 +384,12 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 		expanded_data[i].set(0,255); // every luminance pixel = 255
 		expanded_data[i].set(1,0);
     
-    
+//    bAntiAliased =false;
 		if (bAntiAliased == true){
 			ofPixels bitmapPixels;
-			bitmapPixels.setFromExternalPixels(bitmap.buffer,bitmap.width,bitmap.rows,OF_PIXELS_GRAY); //AO Changed from 1 to OF_PIXELS_GRAY to match oF			expanded_data[i].setChannel(1,bitmapPixels);
-		} else {
+			bitmapPixels.setFromExternalPixels(bitmap.buffer,bitmap.width,bitmap.rows, OF_PIXELS_GRAY); //AO Changed from 1 to OF_PIXELS_GRAY to match oF			expanded_data[i].setChannel(1,bitmapPixels);
+      expanded_data[i].setChannel(1, bitmapPixels);
+    } else {
 			//-----------------------------------
 			// true type packs monochrome info in a
 			// 1-bit format, hella funky

--- a/src/ofxSosoTrueTypeFont.cpp
+++ b/src/ofxSosoTrueTypeFont.cpp
@@ -374,6 +374,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 		stretch = 0;//(float)(visibleBorder * 2);
 
     // TODO: Ask Eric about this correction (AO)
+    // However, it seems that corr is unused???
 //		corr	= (float)(( (fontSize - fheight) + top) - fontSize);
     
 

--- a/src/ofxSosoTrueTypeFont.cpp
+++ b/src/ofxSosoTrueTypeFont.cpp
@@ -249,14 +249,14 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
   FT_Error err;
   
   FT_Library library;
-  if (err = FT_Init_FreeType( &library )){
+  if ((err = FT_Init_FreeType( &library ))){
 		ofLog(OF_LOG_ERROR,"ofTrueTypeFont::loadFont - Error initializing freetype lib: FT_Error = %d", err);
 		return false;
 	}
   
 	FT_Face face;
   
-	if (err = FT_New_Face( library, filename.c_str(), 0, &face )) {
+	if ((err = FT_New_Face( library, filename.c_str(), 0, &face ))) {
     // simple error table in lieu of full table (see fterrors.h)
     string errorString = "unknown freetype";
     if(err == 1) errorString = "INVALID FILENAME";
@@ -451,10 +451,15 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
   
   
   // TODO: oF version > 0.8.4 is slightly different here
-	ofPixels atlasPixels;
-	atlasPixels.allocate(w,h,2);
-	atlasPixels.set(0,255);
-	atlasPixels.set(1,0);
+//	ofPixels atlasPixels;
+//	atlasPixels.allocate(w,h,2);
+//	atlasPixels.set(0,255);
+//	atlasPixels.set(1,0);
+  
+  ofPixels atlasPixelsLuminanceAlpha;
+  atlasPixelsLuminanceAlpha.allocate(w,h,OF_PIXELS_GRAY_ALPHA);
+  atlasPixelsLuminanceAlpha.set(0,255);
+  atlasPixelsLuminanceAlpha.set(1,0);
   
   
 	int x=0;
@@ -476,14 +481,14 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
     cps[sortedCopy[i].characterIndex].t2		= float(cps[sortedCopy[i].characterIndex].tW + x + border)/float(w);
     cps[sortedCopy[i].characterIndex].v2		= float(cps[sortedCopy[i].characterIndex].tH + y + border)/float(h);
 
-    charPixels.pasteInto(atlasPixels,x+border,y+border);
+    charPixels.pasteInto(atlasPixelsLuminanceAlpha,x+border,y+border);
     
 		x+= sortedCopy[i].tW + border*2;
     
 	}
   
   
-	texAtlas.allocate(atlasPixels.getWidth(),atlasPixels.getHeight(),GL_LUMINANCE_ALPHA,false);
+	texAtlas.allocate(atlasPixelsLuminanceAlpha,false);
   
 	if(bAntiAliased && fontsize>20){
 		if (makeMipMaps) { //soso
@@ -496,7 +501,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 		texAtlas.setTextureMinMagFilter(GL_NEAREST,GL_NEAREST);
 	}
   
-	texAtlas.loadData(atlasPixels.getPixels(),atlasPixels.getWidth(),atlasPixels.getHeight(),GL_LUMINANCE_ALPHA);
+	texAtlas.loadData(atlasPixelsLuminanceAlpha);
   
   
   ///////////////////////////////////////////////////////////////////////sosoAddon
@@ -512,7 +517,8 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
     glTexParameteri( texAtlas.getTextureData().textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri( texAtlas.getTextureData().textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     gluBuild2DMipmaps(texAtlas.getTextureData().textureTarget, texAtlas.getTextureData().glTypeInternal,
-                      w, h, texAtlas.getTextureData().glTypeInternal, ofGetGlTypeFromInternal(texAtlas.getTextureData().glTypeInternal), atlasPixels.getPixels());
+                      w, h, texAtlas.getTextureData().glTypeInternal, ofGetGlTypeFromInternal(texAtlas.getTextureData().glTypeInternal), atlasPixelsLuminanceAlpha.getData());
+
     glDisable(texAtlas.getTextureData().textureTarget);
   }
   //////////////////////////////////////////////////////////////////////

--- a/src/ofxSosoTrueTypeFont.cpp
+++ b/src/ofxSosoTrueTypeFont.cpp
@@ -56,7 +56,6 @@ ofxSosoMappedChar::~ofxSosoMappedChar()
 
 
 
-
 //BAD! static global vars in ofTrueTypeFont.cpp
 static bool printVectorInfo = false;
 static int ttfGlobalDpi = 72;   //this is standard dpi to get you pixel-accurate pointsizes. OF uses 96, which yields incorrect point-sizing
@@ -301,9 +300,15 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 	//--------------------- load each char -----------------------
 	for (int i = 0 ; i < nCharacters; i++){
     
+    // AO
+    int glyph = (unsigned char)(i+NUM_CHARACTER_TO_START);
+    
+    // TODO: May be handled by special chars map
+    if (glyph == 0xA4) glyph = 0x20AC; // hack to load the euro sign, all codes in 8859-15 match with utf-32 except for this one
+    
 		//------------------------------------------ anti aliased or not:
 		//if(err = FT_Load_Glyph( face, FT_Get_Char_Index( face, (unsigned char)(i+NUM_CHARACTER_TO_START) ), FT_LOAD_DEFAULT )){
-		if(err = FT_Load_Glyph( face, getFTCharIndex( face, (unsigned char)(i+NUM_CHARACTER_TO_START) ), FT_LOAD_DEFAULT )){		//soso replaced FT_Get_Char_Index with our custom version
+		if((err = FT_Load_Glyph( face, getFTCharIndex( face, (unsigned char)(i+NUM_CHARACTER_TO_START) ), FT_LOAD_DEFAULT ))){		//soso replaced FT_Get_Char_Index with our custom version
 			ofLog(OF_LOG_ERROR,"ofTrueTypeFont::loadFont - Error with FT_Load_Glyph %i: FT_Error = %d", i, err);
       
 		}
@@ -312,7 +317,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 		else FT_Render_Glyph(face->glyph, FT_RENDER_MODE_MONO);
     
 		//------------------------------------------
-		FT_Bitmap& bitmap= face->glyph->bitmap;
+
     
     
 		// prepare the texture:
@@ -341,41 +346,41 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
     
 		// -------------------------
 		// info about the character:
-		cps[i].character		= i;
-		cps[i].height 			= face->glyph->bitmap_top;
-		cps[i].width        = face->glyph->bitmap.width;
-		cps[i].setWidth 		= face->glyph->advance.x >> 6;
-		cps[i].topExtent 		= face->glyph->bitmap.rows;
-		cps[i].leftExtent		= face->glyph->bitmap_left;
+    FT_Bitmap& bitmap= face->glyph->bitmap;
+    int width  = bitmap.width;
+    int height = bitmap.rows;
     
-		int width  = cps[i].width;
-		int height = bitmap.rows;
+		cps[i].characterIndex		= i;
+    cps[i].glyph        = glyph;
+		cps[i].height 			= face->glyph->metrics.height>>6;
+		cps[i].width        = face->glyph->metrics.width>>6;
+    cps[i].bearingX     = face->glyph->metrics.horiBearingX>>6;
+    cps[i].bearingY     = face->glyph->metrics.horiBearingY>>6;
+    cps[i].xmin         = face->glyph->bitmap_left;
+    cps[i].xmax         = cps[i].xmin + cps[i].width;
+    cps[i].ymin         = -face->glyph->bitmap_top;
+    cps[i].ymax         = cps[i].ymin + cps[i].height;
+    cps[i].advance      = face->glyph->metrics.horiAdvance>>6;
     
     
-		cps[i].tW				= width;
-		cps[i].tH				= height;
+    cps[i].tW				= cps[i].width;
+    cps[i].tH				= cps[i].height;
     
-    
+    areaSum += (cps[i].tW+border*2)*(cps[i].tH+border*2);
     
 		GLint fheight	= cps[i].height;
 		GLint bwidth	= cps[i].width;
-		GLint top		= cps[i].topExtent - cps[i].height;
-		GLint lextent	= cps[i].leftExtent;
-    
+
 		GLfloat	corr, stretch;
     
 		//this accounts for the fact that we are showing 2*visibleBorder extra pixels
 		//so we make the size of each char that many pixels bigger
 		stretch = 0;//(float)(visibleBorder * 2);
+
+    // TODO: Ask Eric about this correction (AO)
+//		corr	= (float)(( (fontSize - fheight) + top) - fontSize);
     
-		corr	= (float)(( (fontSize - fheight) + top) - fontSize);
-    
-		cps[i].x1		= lextent + bwidth + stretch;
-		cps[i].y1		= fheight + corr + stretch;
-		cps[i].x2		= (float) lextent;
-		cps[i].y2		= -top + corr;
-    
-    
+
 		// Allocate Memory For The Texture Data.
 		expanded_data[i].allocate(width, height, 2);
 		//-------------------------------- clear data:
@@ -411,7 +416,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 			//-----------------------------------
 		}
     
-		areaSum += (cps[i].width+border*2)*(cps[i].height+border*2);
+		
 	}
   
   
@@ -451,7 +456,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 	}
   
   
-  
+  // TODO:
 	ofPixels atlasPixels;
 	atlasPixels.allocate(w,h,2);
 	atlasPixels.set(0,255);
@@ -462,20 +467,25 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 	int y=0;
 	int maxRowHeight = sortedCopy[0].tH + border*2;
 	for(int i=0;i<(int)cps.size();i++){
-		ofPixels & charPixels = expanded_data[sortedCopy[i].character];
+
+    ofPixels & charPixels = expanded_data[sortedCopy[i].characterIndex];
     
 		if(x+sortedCopy[i].tW + border*2>w){
 			x = 0;
 			y += maxRowHeight;
 			maxRowHeight = sortedCopy[i].tH + border*2;
 		}
+
+    // alex
+    cps[sortedCopy[i].characterIndex].t1		= float(x + border)/float(w);
+    cps[sortedCopy[i].characterIndex].v1		= float(y + border)/float(h);
+    cps[sortedCopy[i].characterIndex].t2		= float(cps[sortedCopy[i].characterIndex].tW + x + border)/float(w);
+    cps[sortedCopy[i].characterIndex].v2		= float(cps[sortedCopy[i].characterIndex].tH + y + border)/float(h);
+
+    charPixels.pasteInto(atlasPixels,x+border,y+border);
     
-		cps[sortedCopy[i].character].t2		= float(x + border)/float(w);
-		cps[sortedCopy[i].character].v2		= float(y + border)/float(h);
-		cps[sortedCopy[i].character].t1		= float(cps[sortedCopy[i].character].tW + x + border)/float(w);
-		cps[sortedCopy[i].character].v1		= float(cps[sortedCopy[i].character].tH + y + border)/float(h);
-		charPixels.pasteInto(atlasPixels,x+border,y+border);
 		x+= sortedCopy[i].tW + border*2;
+    
 	}
   
   
@@ -522,6 +532,7 @@ bool ofxSosoTrueTypeFont::loadFont(string filename, int fontsize, bool _bAntiAli
 			kerningPairs[i][j] = 0;
 		}
 	}
+  
 	//find out if the face has kerning
 	FT_Bool use_kerning = (FT_Bool)FT_HAS_KERNING(face);
 	if(!use_kerning) printf("ofxSosoTrueTypeFont::loadFont() - kerning is NOT supported for %s\n", (char*)filename.c_str());
@@ -842,14 +853,18 @@ float ofxSosoTrueTypeFont::getKerningAdjustment(int c1, int c2)
 {
 	if ((c1 < FONT_NUM_CHARS) && (c2 < FONT_NUM_CHARS)){
     return (float)kerningPairs[c1][c2];
+    
+//    return 10.0f; //TODO: test
 	}else{
 		return 0;
 	}
 }
 
+
 //=====================================================================
 void ofxSosoTrueTypeFont::drawString(string c, float x, float y) {
   
+  ofLogNotice("Calling draw string!");
   /*glEnable(GL_BLEND);
    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
    texAtlas.draw(0,0);*/
@@ -862,7 +877,6 @@ void ofxSosoTrueTypeFont::drawString(string c, float x, float y) {
 	GLint		index	= 0;
 	GLfloat		X		= x;
 	GLfloat		Y		= y;
-  
   
 	bool alreadyBinded = binded;
   
@@ -877,10 +891,7 @@ void ofxSosoTrueTypeFont::drawString(string c, float x, float y) {
 		}
     
 		int cy = (unsigned char)c[index] - NUM_CHARACTER_TO_START;
-		//soso - kerning support
-		//int cz;
-		//if(index < (len-1)) cz = (unsigned char)c[index+1] - NUM_CHARACTER_TO_START;
-    
+
 		if (cy < nCharacters){ 			// full char set or not?
       if (c[index] == '\n') {
         
@@ -893,23 +904,30 @@ void ofxSosoTrueTypeFont::drawString(string c, float x, float y) {
         //printf("c[%d] = ' '\n", index);
         
       } else {
-				//drawChar(cy, X, Y);
+
 				int cM = getMappedChar(c, index); //here is where we check for special unicode sequences, as defined in buildMappedChars()
 				drawChar(cM, X, Y);
-				//printf("c[%d] = %c\n", index, cM + NUM_CHARACTER_TO_START);
-        
+
 				if(isKerningEnabled && index < (len-1)){	//soso - kerning adjustment
-					X += (cps[cM].setWidth + getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START)) * letterSpacing;
+					X += (cps[cM].advance + getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START)) * letterSpacing;
+          
+          // TODO: Ask eric about difference between getKerningAdjustment and getKerning
+//          X += getKerningAdjustment(cy, prevCy);
+          
+          
 					//if(fabs(getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START)) > 0)
           //printf("kern %c%c = %f\n", cM + NUM_CHARACTER_TO_START,  (unsigned char)c[index+1], getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START));
-				}else{
-					//X += cps[cy].setWidth * letterSpacing;
-					X += cps[cM].setWidth * letterSpacing;
+				}else {
+
+          // AO
+          X += cps[cM].advance * letterSpacing;
+
 				}
         
 			}
 		}
 		index++;
+
 	}
   
 	if(!alreadyBinded) unbind();
@@ -919,6 +937,7 @@ void ofxSosoTrueTypeFont::drawString(string c, float x, float y) {
 //Modified to flip the vertically flip the text.
 void ofxSosoTrueTypeFont::drawStringAsShapes(string c, float x, float y) {
   
+  ofLogNotice("Calling draw string as shapes!");
   if (!bLoadedOk){
     ofLog(OF_LOG_ERROR,"ofTrueTypeFont::drawStringAsShapes - Error : font not allocated -- line %d in %s", __LINE__,__FILE__);
     return;
@@ -950,14 +969,16 @@ void ofxSosoTrueTypeFont::drawStringAsShapes(string c, float x, float y) {
 		  }else if (c[index] == ' ') {
         int cy = (int)'p' - NUM_CHARACTER_TO_START;
         X += cps[cy].width;
-        //glTranslated(cps[cy].width, 0, 0);
+        
 		  } else {
-				drawCharAsShape(cy, X, Y);
-				X += cps[cy].setWidth;
-				//glTranslated(cps[cy].setWidth, 0, 0);
+        // AO
+        drawCharAsShape(cy, X, Y);
+        X += (cps[cy].width);
+
 		  }
 		}
 		index++;
+
 	}
   
 	ofPopMatrix();
@@ -968,45 +989,51 @@ void ofxSosoTrueTypeFont::drawStringAsShapes(string c, float x, float y) {
 //-----------------------------------------------------------
 void ofxSosoTrueTypeFont::drawChar(int c, float x, float y) {
   
+  ofLogNotice("Calling draw char!");
   //printf("ofxSosoTrueTypeFont::drawChar()\n");
   
 	if (c >= nCharacters){
 		//ofLog(OF_LOG_ERROR,"Error : char (%i) not allocated -- line %d in %s", (c + NUM_CHARACTER_TO_START), __LINE__,__FILE__);
 		return;
 	}
+
   
-	GLfloat	x1, y1, x2, y2;
-	GLfloat t1, v1, t2, v2;
+  int xmin, ymin, xmax, ymax;
+  float t1, v1, t2, v2;
   
 	t2		= cps[c].t2;
 	v2		= cps[c].v2;
   t1		= cps[c].t1;
 	v1		= cps[c].v1;
-  
-  //ofTrueTypeFont - original for inverted Y
 
-	//x1		= cps[c].x1+x;
-	//y1		= cps[c].y1+y;
-  //x2		= cps[c].x2+x;
-	//y2		= cps[c].y2+y;
+  // ofTrueTypeFont - original for inverted Y
+//  xmin  = cps[c].xmin+x;
+//  ymin  = cps[c].ymin;
+//  xmax  = cps[c].xmax+x;
+//  ymax  = cps[c].ymax;
   
-  //soso - this is how we used to do it INCORRECT
-	//soso - right side up text
-	//y2 *= -1;
-	//y1 *= -1;
+  // soso - updated buttery flip flop
+  xmin  = cps[c].xmin+x;
+  ymin  = -cps[c].ymin;
+  xmax  = cps[c].xmax+x;
+  ymax  = -cps[c].ymax;
+
+  
   
   //soso - this is the buttery flip-flop
-  x1		= cps[c].x1+x;
-	y1		= -cps[c].y1+y;
-  x2		= cps[c].x2+x;
-	y2		= -cps[c].y2+y;
+//  x1		= cps[c].x1+x;
+//	y1		= -cps[c].y1+y;
+//  x2		= cps[c].x2+x;
+//	y2		= -cps[c].y2+y;
 	
 	int firstIndex = stringQuads.getVertices().size();
+
   
-	stringQuads.addVertex(ofVec3f(x1,y1));
-	stringQuads.addVertex(ofVec3f(x2,y1));
-	stringQuads.addVertex(ofVec3f(x2,y2));
-	stringQuads.addVertex(ofVec3f(x1,y2));
+  // AO
+  stringQuads.addVertex(ofVec3f(xmin,ymin));
+  stringQuads.addVertex(ofVec3f(xmax,ymin));
+  stringQuads.addVertex(ofVec3f(xmax,ymax));
+  stringQuads.addVertex(ofVec3f(xmin,ymax));
   
 	stringQuads.addTexCoord(ofVec2f(t1,v1));
 	stringQuads.addTexCoord(ofVec2f(t2,v1));
@@ -1028,6 +1055,8 @@ void ofxSosoTrueTypeFont::drawChar(int c, float x, float y) {
 //guts are adapted from drawString()
 vector <ofVec2f>  ofxSosoTrueTypeFont::getCharPositions(string c, float x, float y)
 {
+  
+  ofLogNotice("Calling get char positions!");
 	vector<ofVec2f> charPositions;
 	
 	if (!bLoadedOk){
@@ -1040,29 +1069,34 @@ vector <ofVec2f>  ofxSosoTrueTypeFont::getCharPositions(string c, float x, float
 	GLfloat		Y		= y;
 	
 	int len = (int)c.length();
-	
+  
 	while(index < len){
 		int cy = (unsigned char)c[index] - NUM_CHARACTER_TO_START;
 		if (cy < nCharacters){ 			// full char set or not?
 			if (c[index] == '\n') {
 				Y -= (float)lineHeight;
 				X = x ; //reset X Pos back to zero (aka x)
-			}
-			else if (c[index] == ' ') {
+			
+      }else if (c[index] == ' ') {
 				int cy = (int)'p' - NUM_CHARACTER_TO_START;
-				//X += cps[cy].width;
+
 				X += (cps[cy].width + letterSpacing);					//soso
-			}
-			else {
+
+        
+			} else {
+        
 				int cM = getMappedChar(c, index); //here is where we check for special unicode sequences, as defined in buildMappedChars()
-				//drawChar(cM, X, Y);
+			
 				//instead of drawing, push back char draw position onto vector
 				charPositions.push_back(ofVec2f(X, Y));
         
 				if(isKerningEnabled && index < (len-1)){	//soso - kerning adjustment
-					X += (cps[cM].setWidth + getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START)) * letterSpacing;
+
+          					X += (cps[cM].width + getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START)) * letterSpacing;
+
 				}else{
-					X += cps[cM].setWidth * letterSpacing;
+
+          X += cps[cy].width * letterSpacing;
 				}
 			}
 		}
@@ -1079,9 +1113,18 @@ float ofxSosoTrueTypeFont::stringWidth(string c)
   return rect.width;
 }
 
+//alex
+float ofxSosoTrueTypeFont::stringHeight(string c)
+{
+  ofRectangle rect = getStringBoundingBox(c, 0,0);
+  return rect.height;
+}
+
 
 ofRectangle ofxSosoTrueTypeFont::getStringBoundingBox(string c, float x, float y)
 {
+  
+  ofLogNotice("Calling get string bounding box!");
   ofRectangle myRect;
   
   if (!bLoadedOk){
@@ -1089,72 +1132,87 @@ ofRectangle ofxSosoTrueTypeFont::getStringBoundingBox(string c, float x, float y
     return myRect;
   }
   
-	GLint		index	= 0;
-	GLfloat		xoffset	= 0;
-	GLfloat		yoffset	= 0;
-  int         len     = (int)c.length();
-  float       minx    = -1;
-  float       miny    = -1;
-  float       maxx    = -1;
-  float       maxy    = -1;
+  // ao
+  int           index = 0;
+  int           xoffset = 0;
+  int           yoffset = 0;
+  int           len = (int) c.length();
+  int           xmin = -1;
+  int           ymin = -1;
+  int           xmax = -1;
+  int           ymax = -1;
   
   if ( len < 1 || cps.empty() ){
-    myRect.x        = 0;
-    myRect.y        = 0;
+    
+    myRect.x        = x;
+    myRect.y        = y;
     myRect.width    = 0;
     myRect.height   = 0;
     return myRect;
   }
   
   bool bFirstCharacter = true;
+
 	while(index < len){
-		int cy = (unsigned char)c[index] - NUM_CHARACTER_TO_START;
+    
+		int cy = ((unsigned char)c[index]) - NUM_CHARACTER_TO_START;
     if (cy < nCharacters){ 			// full char set or not?
       if (c[index] == '\n') {
 				yoffset += lineHeight;
 				xoffset = 0 ; //reset X Pos back to zero
-      } else if (c[index] == ' ') {
+        
+				int cM = getMappedChar(c, index); //soso - check for special unicode sequences, as defined in buildMappedChars()
+
+      }else if (c[index] == ' '){
+        
         int cy = (int)'p' - NUM_CHARACTER_TO_START;
         xoffset += cps[cy].width * letterSpacing * spaceSize;
-        // zach - this is a bug to fix -- for now, we don't currently deal with ' ' in calculating string bounding box
-		  } else {
-				int cM = getMappedChar(c, index); //soso - check for special unicode sequences, as defined in buildMappedChars()
-        
-				//soso - lookup with cM rather than cy
-        GLint height	= cps[cM].height;
-        GLint bwidth	= cps[cM].width * letterSpacing;
-        GLint top		= cps[cM].topExtent - cps[cM].height;
-        GLint lextent	= cps[cM].leftExtent;
-        
-        float	x1, y1, x2, y2, corr, stretch;
-        stretch = 0;//(float)visibleBorder * 2;
-				corr = (float)(((fontSize - height) + top) - fontSize);
-				x1		= (x + xoffset + lextent + bwidth + stretch);
-        y1		= (y + yoffset + height + corr + stretch);
-        x2		= (x + xoffset + lextent);
-        y2		= (y + yoffset + -top + corr);
-				xoffset += cps[cM].setWidth * letterSpacing;		//soso - lookup with cM rather than cy
-				if (bFirstCharacter == true){
-          minx = x2;
-          miny = y2;
-          maxx = x1;
-          maxy = y1;
-          bFirstCharacter = false;
+
         } else {
-          if (x2 < minx) minx = x2;
-          if (y2 < miny) miny = y2;
-          if (x1 > maxx) maxx = x1;
-          if (y1 > maxy) maxy = y1;
+          
+          //TODO TODO TODO
+          
+          int cM = getMappedChar(c, index);
+      
+          
+          if (bFirstCharacter){
+            xmin = cps[cM].xmin+x;
+            ymin = cps[cM].ymin+y;
+            xmax = cps[cM].xmax+x;
+            ymax = cps[cM].ymax+y;
+            bFirstCharacter = false;
+          } else {
+
+            xoffset += 	(cps[cM].width + getKerningAdjustment(cM, (unsigned char)c[index+1] - NUM_CHARACTER_TO_START)) * letterSpacing;
+            
+            int charxmin = cps[cM].xmin+xoffset+x;
+            int charymin = cps[cM].ymin+yoffset+y;
+            int charxmax = cps[cM].xmax+xoffset+x;
+            int charymax = cps[cM].ymax+yoffset+y;
+            
+            if (charxmin < xmin) xmin = charxmin;
+            if (charymin < ymin) ymin = charymin;
+            if (charxmax > xmax) xmax = charxmax;
+            if (charymax > ymax) ymax = charymax;
+            
+          }
+          
+          xoffset += cps[cM].advance * letterSpacing;
+
         }
+      
 		  }
-    }
+
     index++;
+
+
   }
+
+  myRect.x        = min((int)x,xmin);
+  myRect.y        = min((int)y,ymin);
+  myRect.width    = xmax - x;
+  myRect.height   = ymax - ymin;
   
-  myRect.x        = minx;
-  myRect.y        = miny;
-  myRect.width    = maxx-minx;
-  myRect.height   = maxy-miny;
   return myRect;
 
 }

--- a/src/ofxSosoTrueTypeFont.h
+++ b/src/ofxSosoTrueTypeFont.h
@@ -65,6 +65,7 @@ public:
   
 	//overridden for special Unicode character replacements
 	float                   stringWidth(string s);
+  float                   stringHeight(string s);
 	ofRectangle             getStringBoundingBox(string c, float x, float y);
   
 	//new methods

--- a/src/ofxTextObject.cpp
+++ b/src/ofxTextObject.cpp
@@ -884,6 +884,8 @@ void ofxTextObject::_loadWords()
         tmpWord.convertedWord = ofxSosoTrueTypeFont::convertStringTo255(wordString);
 				tmpWord.width   = font->stringWidth(tmpWord.rawWord);
 				tmpWord.height  = font->stringHeight(tmpWord.rawWord);
+
+
 				tmpWord.color.r = material->color.r;
 				tmpWord.color.g = material->color.g;
 				tmpWord.color.b = material->color.b;
@@ -926,6 +928,7 @@ void ofxTextObject::_loadWords()
     tmpWord.convertedWord = ofxSosoTrueTypeFont::convertStringTo255(wordString);
 		tmpWord.width   = font->stringWidth(tmpWord.rawWord);
 		tmpWord.height  = font->stringHeight(tmpWord.rawWord);
+    
 		tmpWord.color.r = material->color.r;
 		tmpWord.color.g = material->color.g;
 		tmpWord.color.b = material->color.b;

--- a/src/ofxVideoPlayerObject.cpp
+++ b/src/ofxVideoPlayerObject.cpp
@@ -2,9 +2,9 @@
 
 ofxVideoPlayerObject::ofxVideoPlayerObject(char *iPath)
 {
-  player = new ofxAVFVideoPlayer();
+  player = new ofAVFoundationPlayer();
   
-  player->loadMovie(iPath);
+  player->load(iPath);
   player->getTextureReference().texData.bFlipTexture = true;
   
 	isCentered = false;

--- a/src/ofxVideoPlayerObject.h
+++ b/src/ofxVideoPlayerObject.h
@@ -23,8 +23,8 @@
 
 #pragma once
 #include "ofxObject.h"
+#include "ofAVFoundationPlayer.h"
 //#include "ofVideoPlayer.h"
-#include "ofxAVFVideoPlayer.h"
 
 class ofxVideoPlayerObject : public ofxObject
 {
@@ -46,7 +46,9 @@ public:
 	bool						isCentered;
 	bool						isAutoIdling;
   bool            isPlaying = false;
-  ofxAVFVideoPlayer *player;
+//  ofxAVFVideoPlayer *player;
+  
+  ofAVFoundationPlayer *player;
   ofShader        *mShader = 0;
   
 };


### PR DESCRIPTION
This version brings us up to date with the master branch of oF as of 12/3/2014.  

Changes include:
Removal of ofxAVFVideoPlayer repo references from all examples (included in oF master)
Modification of ofxVideoPlayerObject to use of AVFoundationPlayer object
Modification of ofxSosoTrueTypeFont to make it compatible with the changes in ofTrueTypeFont (several changes), while preserving custom character mapping
Updated README and CHANGELOG
